### PR TITLE
Fix Docker container environment for Nextflow 25.04.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             aligner: "kallisto"
             test_type: "single-end"
           # Test with latest Nextflow version
-          - NXF_VER: "23.10.1"
+          - NXF_VER: "25.04.0"
             NXF_EDGE: ""
             aligner: "bwa"
             test_type: "single-end"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ COPY environment.yml /app
 
 RUN conda env create -f environment.yml
 
-RUN echo "conda activate bact_seq-1.0.0" >> ~/.bashrc
+# Activate the conda environment permanently
+RUN conda activate bact_seq-1.0.0
+ENV CONDA_DEFAULT_ENV=bact_seq-1.0.0
 ENV PATH=/opt/conda/envs/bact_seq-1.0.0/bin:$PATH
 
 SHELL ["/bin/bash", "-c"]
 
 COPY . /app
-
-ENTRYPOINT ["bash", "-c", "source activate bact_seq-1.0.0 && exec bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ COPY environment.yml /app
 
 RUN conda env create -f environment.yml
 
-# Activate the conda environment permanently
-RUN conda activate bact_seq-1.0.0
+# Set conda environment as default
 ENV CONDA_DEFAULT_ENV=bact_seq-1.0.0
 ENV PATH=/opt/conda/envs/bact_seq-1.0.0/bin:$PATH
 


### PR DESCRIPTION
## Summary
- Remove problematic conda activate RUN command from Dockerfile
- Use environment variables to properly set conda environment path
- Fixes CI failures with Nextflow 25.04.0 where processes couldn't find tools

## Test plan
- [x] Verify Docker image builds successfully
- [x] Confirm CI passes with Nextflow 25.04.0
- [x] Validate tools are accessible in container environment