### PR TITLE
Merge develop into main: TPM, efficient counting, sort CPU fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,17 @@ The pipeline performs the following steps:
 ### Core Analysis
 
 1. **Quality Control & Trimming**
-
    - Trim adaptors from reads ([`Trim Galore!`](https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/))
    - Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
 
 2. **Read Alignment** (choose one)
-
    - **BWA**: Align reads to reference genome ([`BWA-MEM`](https://github.com/lh3/bwa/))
    - **Kallisto**: Pseudo-align reads to coding sequences ([`Kallisto`](https://pachterlab.github.io/kallisto/))
 
 3. **Expression Quantification & Normalization**
-
    - Size-factor scaling using [`DESeq2`](https://bioconductor.org/packages/release/bioc/html/DESeq2.html)
    - TMM normalization using [`edgeR`](http://bioconductor.org/packages/release/bioc/html/edgeR.html)
-   - RPKM scaling for gene length normalization
+   - TPM scaling for gene length normalization
 
 4. **Exploratory Analysis**
    - Principal component analysis (PCA) of normalized expression values
@@ -55,7 +52,6 @@ The pipeline performs the following steps:
 ### Optional Analysis
 
 5. **Differential Expression** ([`DESeq2`](https://bioconductor.org/packages/release/bioc/html/DESeq2.html))
-
    - Pairwise comparisons based on provided contrasts
    - Volcano plots and summary statistics
 
@@ -130,7 +126,6 @@ nextflow run BactSeq \
 ### Required Files
 
 1. **Sample Sheet** (`samples.tsv`)
-
    - TSV file containing sample information with the following columns:
      - `sample`: Sample ID
      - `file1`: Name of R1 FastQ file
@@ -149,7 +144,6 @@ nextflow run BactSeq \
    ```
 
 2. **Reference Genome** (`genome.fasta`)
-
    - FASTA file containing the reference genome sequence
    - Can be downloaded from NCBI RefSeq
 
@@ -160,7 +154,6 @@ nextflow run BactSeq \
 ### Optional Files
 
 1. **Contrasts Table** (`contrasts.tsv`) - _For differential expression_
-
    - TSV file with 2 columns defining comparisons to perform
    - Column names: `Condition1`, `Condition2`
 
@@ -174,7 +167,6 @@ nextflow run BactSeq \
    ```
 
 2. **Functional Annotation File** (`functional_annotation.csv`) - _For enrichment analysis_
-
    - CSV file containing GO terms for genes
    - Column 1: Gene ID (must match `locus_tag` in GFF)
    - Column 2: GO terms (comma-separated)
@@ -206,8 +198,8 @@ The pipeline generates the following output directories:
 
 - `gene_counts.tsv`: Raw read counts per gene
 - `deseq_counts.tsv`: DESeq2 normalized counts (log2 transformed)
-- `cpm_counts.tsv`: Counts per million (CPM) normalized
-- `rpkm_counts.tsv`: RPKM normalized counts
+- `cpm_counts.tsv`: Counts per million (CPM): normalized for library size
+- `tpm_counts.tsv`: Transcripts per million (TPM): normalized for both library size and gene length
 
 **Analysis Results:**
 

--- a/bin/normalise_counts.R
+++ b/bin/normalise_counts.R
@@ -72,6 +72,10 @@ gene_lengths_kb <- as.numeric(ref_tab_sub$gene_length) / 1000
 
 rpk <- non_rRNA_counts / gene_lengths_kb
 tpm_mat <- t(t(rpk) / colSums(rpk)) * 1e6
+if (isTRUE(log)) {
+    tpm_mat <- log2(tpm_mat + 1)
+}
+
 tpm_df <- as_tibble(tpm_mat, rownames = "feature_id")
 
 write_tsv(tpm_df, file.path(outdir, "tpm_counts.tsv"))

--- a/bin/normalise_counts.R
+++ b/bin/normalise_counts.R
@@ -67,13 +67,11 @@ cpm_df <- edgeR::cpm(y, log = log) %>%
 
 write_tsv(cpm_df, file.path(outdir, "cpm_counts.tsv"))
 
-## reads per kilobase per million (rpkm) - normalised for lib size + gene length
-y <- DGEList(
-    counts = non_rRNA_counts,
-    genes = tibble(gene.length = as.numeric(ref_tab_sub$gene_length))
-)
-y <- calcNormFactors(y)
-rpkm_df <- edgeR::rpkm(y, log = log) %>%
-    as_tibble(rownames = "feature_id")
+# tpm - normalised for lib size + gene length
+gene_lengths_kb <- as.numeric(ref_tab_sub$gene_length) / 1000
 
-write_tsv(rpkm_df, file.path(outdir, "rpkm_counts.tsv"))
+rpk <- non_rRNA_counts / gene_lengths_kb
+tpm_mat <- t(t(rpk) / colSums(rpk)) * 1e6
+tpm_df <- as_tibble(tpm_mat, rownames = "feature_id")
+
+write_tsv(tpm_df, file.path(outdir, "tpm_counts.tsv"))

--- a/main.nf
+++ b/main.nf
@@ -246,7 +246,7 @@ workflow {
     )
     ch_deseq_counts = NORMALISE_COUNTS.out.deseq_counts
     ch_cpm_counts = NORMALISE_COUNTS.out.cpm_counts
-    ch_rpkm_counts = NORMALISE_COUNTS.out.rpkm_counts
+    ch_tpm_counts = NORMALISE_COUNTS.out.tpm_counts
     // NB the resulting counts are log-transformed by default
 
 

--- a/modules/normalisation.nf
+++ b/modules/normalisation.nf
@@ -10,7 +10,7 @@ process NORMALISE_COUNTS {
     output:
     path 'deseq_counts.tsv', emit: deseq_counts
     path 'cpm_counts.tsv', emit: cpm_counts
-    path 'rpkm_counts.tsv', emit: rpkm_counts
+    path 'tpm_counts.tsv', emit: rpkm_counts
 
     script:
     """

--- a/modules/normalisation.nf
+++ b/modules/normalisation.nf
@@ -10,7 +10,7 @@ process NORMALISE_COUNTS {
     output:
     path 'deseq_counts.tsv', emit: deseq_counts
     path 'cpm_counts.tsv', emit: cpm_counts
-    path 'tpm_counts.tsv', emit: rpkm_counts
+    path 'tpm_counts.tsv', emit: tpm_counts
 
     script:
     """


### PR DESCRIPTION
## Summary

- Add support for log2 transformation when specified
- Output TPM from the normalisation module
- Switch from RPKM to TPM for gene length normalisation
- More efficient counting of mapped reads and fragments
- Fix samtools sort being allocated 0 CPUs when task cpus is 1

## Notes

- The samtools sort fix affects configs where `task.cpus == 1`